### PR TITLE
Refactor: Integrate AuthContext for user profile management

### DIFF
--- a/src/services/Userapi.ts
+++ b/src/services/Userapi.ts
@@ -1,7 +1,12 @@
 import api from './api';
 
-// Get user profile by ID
-export const getUserProfile = (id: string | number) => {
+// Get authenticated user's profile
+export const getAuthenticatedUserProfile = () => {
+  return api.get(`/users/profile`);
+};
+
+// Get any user profile by ID (Admin only)
+export const getUserProfileById = (id: string | number) => {
   return api.get(`/users/${id}`);
 };
 


### PR DESCRIPTION
- Update Profile page to use `useAuth` hook for user details.
- Replace `localStorage` user ID with `user.id` from AuthContext.
- Modify profile fetching to use `getAuthenticatedUserProfile` without explicit user ID.
- Implement role-based logic to conditionally display and update provider information.
- Update `Userapi.ts` to support authenticated profile endpoints.