### PR TITLE
Refactor: Format date of birth for date input

### DIFF
--- a/src/pages/patientdashboard/Profile.tsx
+++ b/src/pages/patientdashboard/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { getAuthenticatedUserProfile, updateUserProfile } from "../../services/Userapi";
-import { useAuth } from "../../context/AuthContext"; // Import useAuth
+import { useAuth } from "../../context/AuthContext";
+import { formatDateToYYYYMMDD } from "../../utils/formatDate"; // Import formatDateToYYYYMMDD
 
 type Address = {
   street: string;
@@ -403,7 +404,7 @@ const Profile: React.FC = () => {
             <input
               type="date"
               name="medicalInfo.dateOfBirth"
-              value={form.medicalInfo.dateOfBirth}
+              value={form.medicalInfo.dateOfBirth ? formatDateToYYYYMMDD(form.medicalInfo.dateOfBirth) : ''}
               onChange={handleChange}
               className="w-full border border-gray-300 px-4 py-2 rounded-lg"
               disabled={!isEditing}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -25,6 +25,25 @@ export const formatDate = (dateString: string): string => {
   }
 };
 
+// Formats a date string to YYYY-MM-DD for input type="date"
+export const formatDateToYYYYMMDD = (dateString: string): string => {
+  if (!dateString) return '';
+
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) {
+      throw new Error('Invalid date');
+    }
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  } catch (error) {
+    console.error('Error formatting date to YYYY-MM-DD:', (error as Error).message);
+    return '';
+  }
+};
+
 // Formats only the date part in Nigerian format (DD/MM/YYYY)
 export const formatDateOnly = (dateString: string): string => {
   if (!dateString) return '';


### PR DESCRIPTION
Add `formatDateToYYYYMMDD` utility function to ensure the `dateOfBirth` value in the patient profile's date input field is always in `YYYY-MM-DD` format. This is crucial for `input type="date"` elements to correctly display and handle date values.